### PR TITLE
Add workflow to build, deploy into prod

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -24,7 +24,9 @@ jobs:
       - run: npm prune --production
       
       # write server fingerprint to known_hosts
-      - run: echo "${{ secrets.SERVER_FINGERPRINT }}" >> ~/.ssh/known_hosts
+      - run: >-
+          mkdir ~/.ssh \
+          && echo "${{ secrets.SERVER_FINGERPRINT }}" >> ~/.ssh/known_hosts
       
       # rsync dist and node_modules to prod
       - run: >-

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -23,6 +23,9 @@ jobs:
       - run: npm run build
       - run: npm prune --production
       
+      # write server fingerprint to known_hosts
+      - run: echo "${{ secrets.SERVER_FINGERPRINT }}" >> ~/.ssh/known_hosts
+      
       # rsync dist and node_modules to prod
       - run: >-
           rsync -rvtal --delete \
@@ -33,5 +36,3 @@ jobs:
       - run: >-
           ssh ${{ secrets.SERVER_USER }}@${{ secrets.SERVER_HOST }} \
             "sudo systemctl restart takehome-air"
-
-# secrets: SERVER_HOST, SERVER_USER, SERVER_PATH, SSH_KEY

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,37 @@
+##
+# Build/Deploy into production
+#
+# @see https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions
+##
+
+name: Deploy
+
+on:
+  push:
+    branches: [ main, jlong/deployment-frequency ]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-24.04
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - run: npm install
+      - run: npm run build
+      - run: npm prune --production
+      
+      # rsync dist and node_modules to prod
+      - run: >-
+          rsync -rvtal --delete \
+            dist node_modules package.json package-lock.json \
+            ${{ secrets.SERVER_USER }}@${{ secrets.SERVER_HOST }}:${{ secrets.SERVER_PATH }}
+      
+      # restart the application
+      - run: >-
+          ssh ${{ secrets.SERVER_USER }}@${{ secrets.SERVER_HOST }} \
+            "sudo systemctl restart takehome-air"
+
+# secrets: SERVER_HOST, SERVER_USER, SERVER_PATH, SSH_KEY

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -23,18 +23,24 @@ jobs:
       - run: npm run build
       - run: npm prune --production
       
-      # write server fingerprint to known_hosts
-      - run: >-
+      - name: Add SSH host fingerprint
+        run: >-
           mkdir ~/.ssh \
           && echo "${{ secrets.SERVER_FINGERPRINT }}" >> ~/.ssh/known_hosts
+        
+      - name: Write SSH key
+        run: >-
+          touch ~/.ssh/id_rsa \
+          && chmod 600 ~/.ssh/id_rsa \
+          && echo "${{ secrets.SSH_KEY }}" > ~/.ssh/id_rsa
       
-      # rsync dist and node_modules to prod
-      - run: >-
+      - name: Sync files to production
+        run: >-
           rsync -rvtal --delete \
             dist node_modules package.json package-lock.json \
             ${{ secrets.SERVER_USER }}@${{ secrets.SERVER_HOST }}:${{ secrets.SERVER_PATH }}
       
-      # restart the application
-      - run: >-
+      - name: Restart application
+        run: >-
           ssh ${{ secrets.SERVER_USER }}@${{ secrets.SERVER_HOST }} \
             "sudo systemctl restart takehome-air"


### PR DESCRIPTION
This PR aims to increase deployment frequency by introducing a deployment workflow in Github Actions to replace the need to manually build, SSH in, and restarting the service.

## Expectations

These secrets need to be created (ideally limited to a "production" environment within the repository's settings):

- SERVER_FINGERPRINT
- SERVER_HOST
- SERVER_PATH
- SERVER_USER
- SSH_KEY