### PR TITLE
send 404 instead of crashing when job is not found

### DIFF
--- a/src/controllers/jobsController.ts
+++ b/src/controllers/jobsController.ts
@@ -2,6 +2,7 @@ import { Request, Response } from "express";
 
 import { CreateJobRequest } from "../domain/model/job";
 import * as jobService from "../domain/jobService";
+import { NotFoundError } from "../errors/NotFoundError";
 
 export async function createJob(req: Request, res: Response) {
   const createJobRequest: CreateJobRequest = req.body;
@@ -14,6 +15,19 @@ export async function createJob(req: Request, res: Response) {
 
 export async function getStatus(req: Request, res: Response) {
   const jobId = req.params.id;
-  const jobStatusResponse = await jobService.getStatus(jobId);
-  res.status(200).send(jobStatusResponse);
+  jobService.getStatus(jobId).then((jobStatusResponse) => {
+    res.status(200).send(jobStatusResponse);
+  }).catch((error) => {
+
+    if (error instanceof NotFoundError) {
+      res.status(404).send({
+        error: error.message,
+      });
+    } else {
+      console.error(error);
+      res.status(500).send({
+        error: "Internal server error",
+      });
+    }
+  });
 }

--- a/src/domain/jobService.ts
+++ b/src/domain/jobService.ts
@@ -14,6 +14,7 @@ import {
   updateStatus,
 } from "../repository/jobRepository";
 import { processVideos } from "./videoProcessor";
+import { NotFoundError } from '../errors/NotFoundError';
 
 export async function createJob(
   createJobRequest: CreateJobRequest
@@ -31,7 +32,7 @@ export async function createJob(
 export async function getStatus(id: string): Promise<GetJobStatusResponse> {
   const job = await getJob(id);
   if (!job) {
-    throw new Error(`job ${id} is not found`);
+    throw new NotFoundError(`job ${id} is not found`);
   }
   return new GetJobStatusResponse(Status[job.status]);
 }

--- a/src/errors/NotFoundError.ts
+++ b/src/errors/NotFoundError.ts
@@ -1,0 +1,6 @@
+export class NotFoundError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'NotFoundError';
+  }
+} 


### PR DESCRIPTION
While this does not prevent the job processor from crashing the API when an error occurs, this will prevent bad calls to `/jobs/{id}/status` from bringing down the application